### PR TITLE
feat: add tag pages, per-tag feeds, and a typed tag registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# The global gitignore excludes `TAGS` (the ctags/etags index). macOS is
+# case-insensitive, so that also swallows this route directory — un-ignore it.
+!src/pages/tags/

--- a/src/components/ProjectRow.astro
+++ b/src/components/ProjectRow.astro
@@ -1,20 +1,8 @@
 ---
-export interface ProjectLink {
-	/** Short label — "Repo", "Live", "Docs". */
-	label: string;
-	href: string;
-}
+import type { Project } from '../lib/projects';
+import { TAGS, tagHref } from '../lib/tags';
 
-interface Props {
-	index: string;
-	title: string;
-	summary: string;
-	/** Stack or domain. */
-	tags?: string[];
-	/** Single year, or a range for things with duration worth showing. */
-	year: string;
-	/** Zero or more destinations. Nothing linkable renders as "Private". */
-	links?: ProjectLink[];
+interface Props extends Project {
 	/** The first row carries the heavier rule, matching the design. */
 	first?: boolean;
 }
@@ -65,10 +53,13 @@ const isExternal = (href: string) => /^https?:\/\//.test(href);
 	{/* Starts a fresh row under the title until the lg layout has a slot for it. */}
 	<div class="flex flex-wrap gap-1.5 sm:col-start-2 lg:col-start-auto">
 		{
-			tags.map((tag) => (
-				<span class="border border-rule px-[7px] py-[3px] text-micro tracking-wide text-ink-muted uppercase">
-					{tag}
-				</span>
+			tags.map((key) => (
+				<a
+					href={tagHref(key)}
+					class="border border-rule px-[7px] py-[3px] text-micro tracking-wide text-ink-muted uppercase no-underline transition-colors hover:border-accent hover:text-accent"
+				>
+					{TAGS[key].label}
+				</a>
 			))
 		}
 	</div>

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -2,13 +2,24 @@
 const year = new Date().getFullYear();
 ---
 
+{/*
+	The heavier rule matches the header's, bracketing the page. The feed link
+	lives here rather than in the nav so every page offers it — it is the one
+	subscription that covers the whole site.
+*/}
 <div
-	class="mt-24 flex flex-wrap items-center justify-between gap-4 border-t border-rule px-6 py-8 md:px-18"
+	class="mt-24 flex flex-wrap items-center justify-between gap-x-6 gap-y-3 border-t-2 border-rule-strong px-6 py-5 text-mini tracking-wider uppercase md:px-18"
 >
-	<span class="text-mini tracking-wide text-ink-faint">
-		&copy; {year} Timothy Marias
-	</span>
-	<span class="text-mini tracking-wide text-ink-faint">
-		Built with Astro
+	<span class="text-ink-muted">&copy; {year} Timothy Marias</span>
+
+	<span class="flex flex-wrap items-baseline gap-x-6 gap-y-2">
+		<span class="text-ink-muted">Built with Astro</span>
+		<a
+			href="/feed.xml"
+			class="flex items-baseline gap-1.5 border-b border-ink pb-[2px] text-ink no-underline transition-colors hover:border-accent hover:text-accent"
+		>
+			<span>RSS</span>
+			<span class="text-accent">&#8599;</span>
+		</a>
 	</span>
 </div>

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -8,6 +8,14 @@ const links = [
 ];
 
 const path = Astro.url.pathname;
+
+// Tag pages sit under Notes in the design's nav, so Notes takes the active
+// styling while browsing them — but only the exact URL gets aria-current,
+// which means "this is the page you're on", not "this is the section".
+// Index is exact-match only, or it would light up everywhere.
+const isSection = (href: string) =>
+	path === href ||
+	(href === '/blog/' && (path.startsWith('/blog/') || path.startsWith('/tags/')));
 ---
 
 <div
@@ -28,7 +36,10 @@ const path = Astro.url.pathname;
 				<a
 					href={link.href}
 					aria-current={path === link.href ? 'page' : undefined}
-					class="text-caption tracking-wider text-ink-muted uppercase no-underline transition-colors hover:text-ink aria-[current=page]:text-ink"
+					class:list={[
+						'text-caption tracking-wider uppercase no-underline transition-colors hover:text-ink',
+						isSection(link.href) ? 'text-ink' : 'text-ink-muted',
+					]}
 				>
 					{link.label}
 				</a>

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -37,8 +37,12 @@ const isSection = (href: string) =>
 					href={link.href}
 					aria-current={path === link.href ? 'page' : undefined}
 					class:list={[
-						'text-caption tracking-wider uppercase no-underline transition-colors hover:text-ink',
-						isSection(link.href) ? 'text-ink' : 'text-ink-muted',
+						'text-caption tracking-wider uppercase no-underline transition-colors',
+						// The accent marks where you are; hover is scoped to the
+						// others so it can't override it on the active link.
+						isSection(link.href)
+							? 'text-accent'
+							: 'text-ink-muted hover:text-ink',
 					]}
 				>
 					{link.label}

--- a/src/components/SiteMeta.astro
+++ b/src/components/SiteMeta.astro
@@ -13,6 +13,17 @@ interface Props {
 	modifiedTime?: Date;
 	/** Path to a 1200x630 image, resolved against the site origin. */
 	image?: string;
+	/**
+	 * A narrower feed for this page — a tag's own, say. Listed ahead of the
+	 * site feed so a reader offers the more specific subscription first.
+	 */
+	feed?: { href: string; title: string };
+	/**
+	 * Absolute URL this page should be indexed as. Set it when several routes
+	 * are the same document — the tag index's sort orders, say — so they don't
+	 * compete as duplicates. Defaults to the page's own URL.
+	 */
+	canonical?: string;
 }
 
 const {
@@ -22,13 +33,17 @@ const {
 	publishedTime,
 	modifiedTime,
 	image = '/og/default.png',
+	feed,
+	canonical: canonicalOverride,
 } = Astro.props;
 
 const SITE_NAME = 'Timothy Marias';
 
 // Astro.site is set in the config, so these are absolute — social scrapers
 // reject relative URLs.
-const canonical = new URL(Astro.url.pathname, Astro.site);
+const canonical = canonicalOverride
+	? new URL(canonicalOverride)
+	: new URL(Astro.url.pathname, Astro.site);
 const imageUrl = new URL(image, Astro.site);
 
 // The home page title is the bare name; everything else is suffixed.
@@ -74,5 +89,15 @@ const fullTitle = title === SITE_NAME ? title : `${title} — ${SITE_NAME}`;
 <meta name="twitter:image" content={imageUrl} />
 
 <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+{
+	feed && (
+		<link
+			rel="alternate"
+			type="application/rss+xml"
+			title={feed.title}
+			href={feed.href}
+		/>
+	)
+}
 <link rel="alternate" type="application/rss+xml" title={SITE_NAME} href="/feed.xml" />
 <link rel="sitemap" href="/sitemap-index.xml" />

--- a/src/components/TagIndex.astro
+++ b/src/components/TagIndex.astro
@@ -158,18 +158,16 @@ const schema = {
 			</p>
 		</div>
 
-		{/*
-			Three links, not a control that needs scripting — each ordering is
-			its own pre-built page. `aria-current` marks the active one for
-			assistive tech, since the fill alone only reads visually.
-		*/}
-		<nav
-			aria-label="Sort order"
-			class="flex flex-col gap-3 lg:border-l lg:border-rule lg:pl-6"
-		>
-			<span class="text-micro tracking-[0.1em] text-ink-faint uppercase">
-				Sort
-			</span>
+		<aside class="flex flex-col gap-3 lg:border-l lg:border-rule lg:pl-6">
+			{/*
+				Three links, not a control that needs scripting — each ordering is
+				its own pre-built page. `aria-current` marks the active one for
+				assistive tech, since the fill alone only reads visually.
+			*/}
+			<nav aria-label="Sort order" class="flex flex-col gap-3">
+				<span class="text-micro tracking-[0.1em] text-ink-faint uppercase">
+					Sort
+				</span>
 			<div class="flex flex-wrap gap-1.5">
 				{
 					TAG_SORTS.map((option) => {
@@ -186,12 +184,27 @@ const schema = {
 								]}
 							>
 								{option.label}
-							</a>
-						);
-					})
-				}
-			</div>
-		</nav>
+								</a>
+							);
+						})
+					}
+				</div>
+			</nav>
+
+			{/*
+				The site feed — this page is every tag, so there is no narrower one
+				to offer. Mirrors "Subscribe to this tag" on the single-tag pages.
+			*/}
+			<p class="mt-1.5 border-t border-rule pt-3 text-caption text-ink-faint">
+				Subscribe to every note{' '}
+				<a
+					href="/feed.xml"
+					class="border-b border-ink text-ink no-underline transition-colors hover:border-accent hover:text-accent"
+				>
+					RSS <span class="text-accent">&#8599;</span>
+				</a>
+			</p>
+		</aside>
 	</div>
 
 	<section

--- a/src/components/TagIndex.astro
+++ b/src/components/TagIndex.astro
@@ -158,19 +158,17 @@ const schema = {
 			</p>
 		</div>
 
-		{/*
-			Three links, not a control that needs scripting — each ordering is
-			its own pre-built page. `aria-current` marks the active one for
-			assistive tech, since the fill alone only reads visually.
-		*/}
-		<nav
-			aria-label="Sort order"
-			class="flex flex-col gap-3 lg:border-l lg:border-rule lg:pl-6"
-		>
-			<span class="text-micro tracking-[0.1em] text-ink-faint uppercase">
-				Sort
-			</span>
-			<div class="flex flex-wrap gap-1.5">
+		<aside class="flex flex-col gap-3 lg:border-l lg:border-rule lg:pl-6">
+			{/*
+				Three links, not a control that needs scripting — each ordering is
+				its own pre-built page. `aria-current` marks the active one for
+				assistive tech, since the fill alone only reads visually.
+			*/}
+			<nav aria-label="Sort order" class="flex flex-col gap-3">
+				<span class="text-micro tracking-[0.1em] text-ink-faint uppercase">
+					Sort
+				</span>
+				<div class="flex flex-wrap gap-1.5">
 				{
 					TAG_SORTS.map((option) => {
 						const active = option.segment === segment;
@@ -186,12 +184,27 @@ const schema = {
 								]}
 							>
 								{option.label}
-							</a>
-						);
-					})
-				}
-			</div>
-		</nav>
+								</a>
+							);
+						})
+					}
+				</div>
+			</nav>
+
+			{/*
+				The site feed, not a per-tag one — this page is every tag. Matches
+				the "Subscribe to this tag" affordance on the single-tag pages.
+			*/}
+			<p class="mt-1.5 border-t border-rule pt-3 text-caption text-ink-faint">
+				Subscribe to every note{' '}
+				<a
+					href="/feed.xml"
+					class="border-b border-ink text-ink no-underline transition-colors hover:border-accent hover:text-accent"
+				>
+					RSS <span class="text-accent">&#8599;</span>
+				</a>
+			</p>
+		</aside>
 	</div>
 
 	<section

--- a/src/components/TagIndex.astro
+++ b/src/components/TagIndex.astro
@@ -158,17 +158,19 @@ const schema = {
 			</p>
 		</div>
 
-		<aside class="flex flex-col gap-3 lg:border-l lg:border-rule lg:pl-6">
-			{/*
-				Three links, not a control that needs scripting — each ordering is
-				its own pre-built page. `aria-current` marks the active one for
-				assistive tech, since the fill alone only reads visually.
-			*/}
-			<nav aria-label="Sort order" class="flex flex-col gap-3">
-				<span class="text-micro tracking-[0.1em] text-ink-faint uppercase">
-					Sort
-				</span>
-				<div class="flex flex-wrap gap-1.5">
+		{/*
+			Three links, not a control that needs scripting — each ordering is
+			its own pre-built page. `aria-current` marks the active one for
+			assistive tech, since the fill alone only reads visually.
+		*/}
+		<nav
+			aria-label="Sort order"
+			class="flex flex-col gap-3 lg:border-l lg:border-rule lg:pl-6"
+		>
+			<span class="text-micro tracking-[0.1em] text-ink-faint uppercase">
+				Sort
+			</span>
+			<div class="flex flex-wrap gap-1.5">
 				{
 					TAG_SORTS.map((option) => {
 						const active = option.segment === segment;
@@ -184,27 +186,12 @@ const schema = {
 								]}
 							>
 								{option.label}
-								</a>
-							);
-						})
-					}
-				</div>
-			</nav>
-
-			{/*
-				The site feed, not a per-tag one — this page is every tag. Matches
-				the "Subscribe to this tag" affordance on the single-tag pages.
-			*/}
-			<p class="mt-1.5 border-t border-rule pt-3 text-caption text-ink-faint">
-				Subscribe to every note{' '}
-				<a
-					href="/feed.xml"
-					class="border-b border-ink text-ink no-underline transition-colors hover:border-accent hover:text-accent"
-				>
-					RSS <span class="text-accent">&#8599;</span>
-				</a>
-			</p>
-		</aside>
+							</a>
+						);
+					})
+				}
+			</div>
+		</nav>
 	</div>
 
 	<section

--- a/src/components/TagIndex.astro
+++ b/src/components/TagIndex.astro
@@ -1,0 +1,289 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { allPosts } from '../lib/posts';
+import { projects } from '../lib/projects';
+import {
+	TAGS,
+	TAG_KEYS,
+	TAG_SORTS,
+	sortHref,
+	tagHref,
+	type TagKey,
+	type TagStats,
+} from '../lib/tags';
+import { WEBSITE_ID } from '../lib/schema';
+
+/**
+ * The tag index. One component behind three routes — /tags/, /tags/a-z/ and
+ * /tags/recent/ — because a static build can precompute every ordering, so
+ * the sort control is three links rather than a script. See TAG_SORTS.
+ */
+
+interface Props {
+	/** Which of TAG_SORTS this route renders. */
+	segment: string;
+}
+
+const { segment } = Astro.props;
+
+const sort = TAG_SORTS.find((s) => s.segment === segment)!;
+const isDefault = segment === '';
+
+const posts = await allPosts();
+
+const stats = new Map<TagKey, TagStats>(
+	TAG_KEYS.map((key) => [
+		key,
+		{ key, posts: 0, projects: 0, weight: 0, latest: null },
+	]),
+);
+
+for (const post of posts) {
+	for (const key of post.data.tags) {
+		const row = stats.get(key)!;
+		row.posts += 1;
+		row.weight += 1;
+		// allPosts() is newest-first, so the first one seen is the latest.
+		row.latest ??= post.data.pubDate;
+	}
+}
+for (const project of projects) {
+	for (const key of project.tags ?? []) {
+		const row = stats.get(key)!;
+		row.projects += 1;
+		row.weight += 1;
+	}
+}
+
+// A tag in the registry with nothing pointing at it isn't worth a row. Its
+// page still builds; it just isn't reachable by browsing.
+const used = [...stats.values()].filter((row) => row.weight > 0);
+const ranked = [...used].sort(sort.compare);
+
+/*
+	Single-entry tags collapse into one chip row, but only under Weight — that
+	view is about relative mass, and a long tail of ones drowns out the tags
+	carrying the site. A–Z and Recent are lookup views: collapsing there would
+	hide half the alphabet, so every tag gets a full row.
+*/
+const listed = isDefault ? ranked.filter((row) => row.weight > 1) : ranked;
+const tail = isDefault ? ranked.filter((row) => row.weight === 1) : [];
+
+// Bar width is relative to the heaviest tag, so the column always uses its
+// full extent regardless of how many notes exist.
+const heaviest = Math.max(1, ...ranked.map((row) => row.weight));
+const barPercent = (weight: number) =>
+	Math.max(8, Math.round((weight / heaviest) * 100));
+
+const totalPosts = posts.length;
+const totalProjects = projects.length;
+
+const stamp = (date: Date) =>
+	date
+		.toLocaleDateString('en-GB', {
+			year: '2-digit',
+			month: '2-digit',
+			day: '2-digit',
+			timeZone: 'UTC',
+		})
+		.split('/')
+		.reverse()
+		.join('.');
+
+const canonical = new URL('/tags/', Astro.site).href;
+
+// All three orderings are the same collection, so they share one canonical
+// URL — the sorted variants exist for readers, not as separate documents.
+const schema = {
+	'@type': 'CollectionPage',
+	'@id': `${canonical}#page`,
+	url: canonical,
+	name: 'Tags',
+	description: 'Everything on this site, by subject.',
+	isPartOf: { '@id': WEBSITE_ID },
+	mainEntity: {
+		'@type': 'ItemList',
+		numberOfItems: ranked.length,
+		itemListElement: ranked.map((row, i) => ({
+			'@type': 'ListItem',
+			position: i + 1,
+			url: new URL(tagHref(row.key), Astro.site).href,
+			name: TAGS[row.key].label,
+		})),
+	},
+};
+---
+
+<BaseLayout
+	title={isDefault ? 'Tags' : `Tags — ${sort.label}`}
+	description="Everything on this site, by subject."
+	image="/og/tags.png"
+	canonical={isDefault ? undefined : canonical}
+	schema={schema}
+>
+	<nav
+		aria-label="Breadcrumb"
+		class="flex items-baseline gap-2.5 border-b border-rule px-6 py-5 text-mini tracking-wider uppercase md:px-18"
+	>
+		<a href="/blog/" class="text-ink-faint no-underline hover:text-ink">Notes</a>
+		<span class="text-ink-faint" aria-hidden="true">/</span>
+		<span class="text-ink" aria-current="page">Tags</span>
+	</nav>
+
+	<div
+		class="grid grid-cols-1 gap-x-8 gap-y-10 px-6 pt-14 pb-10 md:grid-cols-[96px_1fr] md:px-18 lg:grid-cols-[96px_1fr_300px]"
+	>
+		<span class="eyebrow pt-2.5">Index</span>
+
+		<div>
+			<h1
+				class="max-w-[620px] text-[2.25rem] leading-display font-bold tracking-tightest text-pretty sm:text-[2.875rem]"
+			>
+				Everything, by subject
+			</h1>
+			<p
+				class="mt-[18px] max-w-[480px] text-[0.9375rem] leading-normal text-ink-muted"
+			>
+				{ranked.length}
+				{ranked.length === 1 ? ' tag' : ' tags'} across {totalPosts}
+				{totalPosts === 1 ? ' note' : ' notes'} and {totalProjects}
+				{totalProjects === 1 ? ' project' : ' projects'}.{' '}
+				{
+					isDefault
+						? 'Sorted by weight — the ones I keep returning to sit at the top.'
+						: sort.segment === 'a-z'
+							? 'Sorted alphabetically.'
+							: 'Sorted by most recent note.'
+				}
+			</p>
+		</div>
+
+		{/*
+			Three links, not a control that needs scripting — each ordering is
+			its own pre-built page. `aria-current` marks the active one for
+			assistive tech, since the fill alone only reads visually.
+		*/}
+		<nav
+			aria-label="Sort order"
+			class="flex flex-col gap-3 lg:border-l lg:border-rule lg:pl-6"
+		>
+			<span class="text-micro tracking-[0.1em] text-ink-faint uppercase">
+				Sort
+			</span>
+			<div class="flex flex-wrap gap-1.5">
+				{
+					TAG_SORTS.map((option) => {
+						const active = option.segment === segment;
+						return (
+							<a
+								href={sortHref(option.segment)}
+								aria-current={active ? 'page' : undefined}
+								class:list={[
+									'px-2.5 py-[5px] text-micro tracking-wider uppercase no-underline transition-colors',
+									active
+										? 'border border-rule-strong bg-rule-strong text-page'
+										: 'border border-rule text-ink-muted hover:border-accent hover:text-accent',
+								]}
+							>
+								{option.label}
+							</a>
+						);
+					})
+				}
+			</div>
+		</nav>
+	</div>
+
+	<section
+		class="grid grid-cols-1 gap-x-8 px-6 pb-16 md:grid-cols-[96px_1fr] md:px-18"
+	>
+		<h2 class="eyebrow pb-4 md:pb-0">
+			{ranked.length}{ranked.length === 1 ? ' tag' : ' tags'}
+		</h2>
+
+		{
+			ranked.length === 0 ? (
+				<p class="text-small text-ink-muted">No tags in use yet.</p>
+			) : (
+				<ul class="border-b border-rule-strong">
+					{listed.map((row, i) => (
+						<li
+							class:list={[
+								i === 0 ? 'border-t border-rule-strong' : 'border-t border-rule',
+							]}
+						>
+							<a
+								href={tagHref(row.key)}
+								class="group grid grid-cols-1 items-baseline gap-x-6 gap-y-1.5 py-4 no-underline md:grid-cols-[230px_1fr] lg:grid-cols-[230px_1fr_170px_110px]"
+							>
+								<h3 class="text-[1.1875rem] font-bold tracking-tight text-ink transition-colors group-hover:text-accent">
+									{TAGS[row.key].label}
+								</h3>
+
+								<p class="text-small leading-normal text-ink-muted">
+									{TAGS[row.key].description ??
+										[
+											row.posts > 0 &&
+												`${row.posts} ${row.posts === 1 ? 'note' : 'notes'}`,
+											row.projects > 0 &&
+												`${row.projects} ${row.projects === 1 ? 'project' : 'projects'}`,
+										]
+											.filter(Boolean)
+											.join(' · ')}
+								</p>
+
+								{/*
+									Relative weight, not a precise quantity — the count beside
+									it carries the number. Hidden below lg with the date, where
+									the row is only two columns wide.
+								*/}
+								<div class="hidden items-center gap-2.5 lg:flex">
+									<span
+										aria-hidden="true"
+										class:list={[
+											'h-1.5 shrink-0',
+											isDefault && i === 0 ? 'bg-accent' : 'bg-rule-strong',
+										]}
+										style={`width: ${barPercent(row.weight)}%`}
+									/>
+									<span class="text-mini text-ink-faint">{row.weight}</span>
+								</div>
+
+								<span class="hidden text-right text-mini text-ink-faint lg:block">
+									{row.latest ? stamp(row.latest) : '—'}
+								</span>
+							</a>
+						</li>
+					))}
+
+					{tail.length > 0 && (
+						<li
+							class:list={[
+								'grid grid-cols-1 items-baseline gap-x-6 gap-y-2 py-4 md:grid-cols-[230px_1fr]',
+								listed.length === 0
+									? 'border-t border-rule-strong'
+									: 'border-t border-rule',
+							]}
+						>
+							<span class="eyebrow">
+								{tail.length === 1
+									? 'One more, a single entry'
+									: `${tail.length} more, one entry each`}
+							</span>
+							<div class="flex flex-wrap gap-1.5">
+								{tail.map((row) => (
+									<a
+										href={tagHref(row.key)}
+										class="border border-rule px-2 py-1 text-micro tracking-wide text-ink-muted uppercase no-underline transition-colors hover:border-accent hover:text-accent"
+									>
+										{TAGS[row.key].label}
+									</a>
+								))}
+							</div>
+						</li>
+					)}
+				</ul>
+			)
+		}
+	</section>
+</BaseLayout>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,11 +1,16 @@
 ---
 ---
 
+{/*
+	The toggle sits in the nav and shares its metrics exactly — the design
+	separates it by colour alone. `eyebrow` was setting a smaller size and its
+	own tracking, which is why it read as a different size.
+*/}
 <button
 	type="button"
 	data-theme-toggle
 	aria-label="Toggle color theme"
-	class="eyebrow cursor-pointer bg-transparent text-ink-muted transition-colors hover:text-ink"
+	class="cursor-pointer bg-transparent text-caption tracking-wider text-ink-faint uppercase transition-colors hover:text-ink"
 >
 	<span data-theme-label>Dark</span>
 </button>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,6 +1,7 @@
 import { defineCollection } from 'astro:content';
 import { glob } from 'astro/loaders';
 import { z } from 'astro/zod';
+import { TAG_KEYS } from './lib/tags';
 
 const blog = defineCollection({
 	loader: glob({ base: './src/content/blog', pattern: '**/*.md' }),
@@ -9,7 +10,9 @@ const blog = defineCollection({
 		description: z.string(),
 		pubDate: z.coerce.date(),
 		updatedDate: z.coerce.date().optional(),
-		tags: z.array(z.string()).default([]),
+		// Keys into TAGS, not display text — an unknown key fails the build
+		// rather than rendering a tag that links nowhere. See src/lib/tags.ts.
+		tags: z.array(z.enum(TAG_KEYS)).default([]),
 		draft: z.boolean().default(false),
 	}),
 });

--- a/src/content/blog/kitchen-sink.md
+++ b/src/content/blog/kitchen-sink.md
@@ -2,7 +2,7 @@
 title: 'Kitchen sink: every element a post might use'
 description: A styling reference covering the full range of markdown output, kept as a draft so it never ships.
 pubDate: 2026-07-26
-tags: ['Reference', 'Typography']
+tags: ['reference', 'typography']
 draft: true
 ---
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,6 +13,10 @@ interface Props {
 	publishedTime?: Date;
 	modifiedTime?: Date;
 	image?: string;
+	/** A feed narrower than the site's — see SiteMeta. */
+	feed?: { href: string; title: string };
+	/** Index this page as another URL — see SiteMeta. */
+	canonical?: string;
 	/**
 	 * This page's own structured data node — a BlogPosting, a ProfilePage.
 	 * Merged into the site's identity graph rather than replacing it, so the

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -24,6 +24,30 @@ export const postsByTag = async (key: TagKey): Promise<Post[]> =>
 	(await allPosts()).filter((post) => post.data.tags.includes(key));
 
 /**
+ * Rounded minutes to read a post, from its markdown source.
+ *
+ * Fenced blocks come out first: a mermaid diagram or a long code listing is
+ * scanned, not read, and counting it as prose overstates a short post badly.
+ * Markup is stripped for the same reason — a URL is one token to a reader,
+ * not the eight "words" its punctuation splits into.
+ *
+ * 200 wpm is the conventional figure for technical prose. Never returns 0,
+ * since "0 min" reads as an error rather than as "short".
+ */
+export const readingMinutes = (post: Post): number => {
+	const prose = post.body
+		?.replace(/^---\n[\s\S]*?\n---/, '') // frontmatter, if the loader kept it
+		.replace(/```[\s\S]*?```/g, '') // fenced code and mermaid
+		.replace(/`[^`]*`/g, '') // inline code
+		.replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1') // links and images, keep text
+		.replace(/^\s{0,3}[#>*+-]+\s*/gm, '') // list and heading markers
+		.replace(/[*_~]/g, ''); // emphasis
+
+	const words = prose?.split(/\s+/).filter(Boolean).length ?? 0;
+	return Math.max(1, Math.round(words / 200));
+};
+
+/**
  * Tags that appear alongside `key`, most frequent first — the "Often with"
  * rail. Counts projects as well as notes, since both carry tags and a
  * co-occurrence that only shows up in project metadata is still real.

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,52 @@
+import { getCollection, type CollectionEntry } from 'astro:content';
+import type { TagKey } from './tags';
+import { projectsByTag } from './projects';
+
+/**
+ * Post queries. Shared so that a tag's post count and the list beneath it are
+ * always computed the same way.
+ *
+ * Drafts stay out of every listing in both dev and production — the same rule
+ * the blog index and home page already followed. Only the post route itself
+ * includes them, so a draft is previewable by URL but never linked.
+ */
+
+export type Post = CollectionEntry<'blog'>;
+
+const byNewest = (a: Post, b: Post) =>
+	b.data.pubDate.valueOf() - a.data.pubDate.valueOf();
+
+/** Listed posts, newest first. Never includes drafts. */
+export const allPosts = async (): Promise<Post[]> =>
+	(await getCollection('blog', ({ data }) => !data.draft)).sort(byNewest);
+
+export const postsByTag = async (key: TagKey): Promise<Post[]> =>
+	(await allPosts()).filter((post) => post.data.tags.includes(key));
+
+/**
+ * Tags that appear alongside `key`, most frequent first — the "Often with"
+ * rail. Counts projects as well as notes, since both carry tags and a
+ * co-occurrence that only shows up in project metadata is still real.
+ */
+export const relatedTags = async (
+	key: TagKey,
+	limit = 6,
+): Promise<{ key: TagKey; count: number }[]> => {
+	const tagSets: readonly (readonly TagKey[])[] = [
+		...(await postsByTag(key)).map((post) => post.data.tags),
+		...projectsByTag(key).map((project) => project.tags ?? []),
+	];
+
+	const counts = new Map<TagKey, number>();
+	for (const tags of tagSets) {
+		for (const other of tags) {
+			if (other === key) continue;
+			counts.set(other, (counts.get(other) ?? 0) + 1);
+		}
+	}
+
+	return [...counts.entries()]
+		.map(([k, count]) => ({ key: k, count }))
+		.sort((a, b) => b.count - a.count)
+		.slice(0, limit);
+};

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,0 +1,67 @@
+import type { TagKey } from './tags';
+
+/**
+ * Projects. Lifted out of the home page because tag pages list them too — a
+ * tag like `caelus` names both a project and the notes written about it, and
+ * that connection is the reason tag pages exist.
+ *
+ * Current work only. The full history lives in the résumé.
+ */
+
+export interface ProjectLink {
+	/** Short label — "Repo", "Live", "Docs". */
+	label: string;
+	href: string;
+}
+
+export interface Project {
+	index: string;
+	title: string;
+	summary: string;
+	/** Stack or domain, as keys into TAGS. */
+	tags?: TagKey[];
+	/** Single year, or a range for things with duration worth showing. */
+	year: string;
+	/** Zero or more destinations. Nothing linkable renders as "Private". */
+	links?: ProjectLink[];
+}
+
+export const projects: Project[] = [
+	{
+		index: '001',
+		title: 'Marias Family Archive',
+		summary:
+			"My WIP project to act as an archive for my family's genealogy from our primary sources." +
+			' Originally built out in Spring Boot with Kotlin, moving it now to Adonis JS. ' +
+			'SSR MPA with TS islands. Self hosted on my NixOS box.',
+		tags: ['familyArchive', 'typescript', 'postgres', 'nixos'],
+		year: '2025—present',
+		links: [
+			{ label: 'Live', href: 'https://mariasfamilyarchive.com' },
+			{
+				label: 'Repo',
+				href: 'https://github.com/timothyjamesmarias/familyArchive',
+			},
+			{
+				label: 'Old',
+				href: 'https://github.com/timothyjamesmarias/familyArchiveV1',
+			},
+		],
+	},
+	{
+		index: '002',
+		title: 'Caelus',
+		summary:
+			"A routing architecture library for being able to expose a program's API across multiple surfaces: keybindings and overrides, CLI, MCP, and web. " +
+			"Originally prototyped as a Kotlin Multiplatform Library, I'm in the process of porting this to TypeScript to be able to provide better web support.",
+		tags: ['caelus', 'typescript', 'crossPlatform'],
+		year: '2026—present',
+		links: [
+			{ label: 'Repo', href: 'https://github.com/ufo-soft/caelus' },
+			{ label: 'Old', href: 'https://github.com/ufo-soft/caelus-old' },
+		],
+	},
+];
+
+export const projectsByTag = (key: TagKey): Project[] =>
+	projects.filter((project) => project.tags?.includes(key));

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,185 @@
+/**
+ * The tag vocabulary. One record per tag, and the only place a tag's display
+ * text or URL is written down.
+ *
+ * This exists because nothing here is backed by a CMS: without a fixed
+ * vocabulary, `Typescript` in a project row and `TypeScript` in a post's
+ * frontmatter are two different tags, and one of them links nowhere. Posts and
+ * projects reference tags by key, the content schema validates against those
+ * keys, and a typo fails the build instead of shipping a dead page.
+ *
+ * `kind` separates the two axes that would otherwise sit in one alphabetical
+ * list — `tech` is a technology or discipline, `project` names a body of work
+ * that both projects and notes can belong to.
+ */
+
+export interface Tag {
+	/** How the tag renders. Free to change; nothing keys off it. */
+	label: string;
+	/** URL segment. Changing one breaks existing links, so treat as permanent. */
+	slug: string;
+	kind: 'tech' | 'project';
+	/** Shown on the tag's own page. Optional — most tags don't need one. */
+	description?: string;
+}
+
+/**
+ * Types every value as `Tag` while still inferring the literal key union.
+ * A bare `as const` would narrow each entry to its own shape, leaving tags
+ * without a `description` with no such property to read.
+ */
+const defineTags = <T extends Record<string, Tag>>(tags: T): { [K in keyof T]: Tag } =>
+	tags;
+
+export const TAGS = defineTags({
+	// Projects — a body of work, spanning however many notes and repos.
+	familyArchive: {
+		label: 'Family Archive',
+		slug: 'family-archive',
+		kind: 'project',
+		description:
+			"An archive for my family's genealogy, built from primary sources.",
+	},
+	caelus: {
+		label: 'Caelus',
+		slug: 'caelus',
+		kind: 'project',
+		description:
+			"A routing architecture library for exposing a program's API across keybindings, CLI, MCP, and web.",
+	},
+
+	// Tech — languages, platforms, disciplines.
+	typescript: { label: 'TypeScript', slug: 'typescript', kind: 'tech' },
+	kotlin: { label: 'Kotlin', slug: 'kotlin', kind: 'tech' },
+	postgres: { label: 'Postgres', slug: 'postgres', kind: 'tech' },
+	nixos: { label: 'NixOS', slug: 'nixos', kind: 'tech' },
+	crossPlatform: { label: 'Cross-Platform', slug: 'cross-platform', kind: 'tech' },
+	mcp: { label: 'MCP', slug: 'mcp', kind: 'tech' },
+	cli: { label: 'CLI', slug: 'cli', kind: 'tech' },
+	typography: { label: 'Typography', slug: 'typography', kind: 'tech' },
+	reference: { label: 'Reference', slug: 'reference', kind: 'tech' },
+});
+
+export type TagKey = keyof typeof TAGS;
+
+/**
+ * `z.enum` needs a non-empty tuple of literals, which `Object.keys` can't
+ * produce on its own. The assertion is safe as long as TAGS is non-empty.
+ */
+export const TAG_KEYS = Object.keys(TAGS) as [TagKey, ...TagKey[]];
+
+export const tag = (key: TagKey): Tag => TAGS[key];
+
+export const tagHref = (key: TagKey): string => `/tags/${TAGS[key].slug}/`;
+
+/** Reverse lookup for `getStaticPaths`, which hands back a slug, not a key. */
+export const keyBySlug = Object.fromEntries(
+	TAG_KEYS.map((key) => [TAGS[key].slug, key]),
+) as Record<string, TagKey>;
+
+/** Alphabetical by label — `TAGS` is ordered for reading, not for display. */
+export const sortedKeys = (keys: readonly TagKey[]): TagKey[] =>
+	[...keys].sort((a, b) => TAGS[a].label.localeCompare(TAGS[b].label));
+
+/* -------------------------------------------------------------------------
+   Sorting for the tag index.
+
+   Each order is a separate pre-built page rather than a client-side control:
+   the site is static, so the build already knows every ordering, and shipping
+   a comparator to the browser would only re-derive what it computed. Three
+   plain pages need no JS, keep DOM order correct for keyboard and screen
+   readers, and are shareable as URLs.
+
+   The comparators take a plain row shape rather than reading TAGS directly,
+   so if this ever does need to move client-side — faceted filtering being the
+   realistic trigger — the logic moves without being rewritten.
+   ------------------------------------------------------------------------- */
+
+/** The per-tag totals the index ranks by. Computed in the page. */
+export interface TagStats {
+	key: TagKey;
+	posts: number;
+	projects: number;
+	/** Notes + projects. */
+	weight: number;
+	/** Most recent post carrying the tag; null when it has none. */
+	latest: Date | null;
+}
+
+export interface TagSort {
+	/** URL segment under /tags/. Empty string is the canonical default. */
+	segment: string;
+	/** Control label, per the design. */
+	label: string;
+	compare: (a: TagStats, b: TagStats) => number;
+}
+
+const byLabel = (a: TagStats, b: TagStats) =>
+	TAGS[a.key].label.localeCompare(TAGS[b.key].label);
+
+export const TAG_SORTS: TagSort[] = [
+	{
+		segment: '',
+		label: 'Weight',
+		// Alphabetical within a tie, so the order is stable build to build
+		// rather than following registry declaration order.
+		compare: (a, b) => b.weight - a.weight || byLabel(a, b),
+	},
+	{
+		segment: 'a-z',
+		label: 'A–Z',
+		compare: byLabel,
+	},
+	{
+		segment: 'recent',
+		label: 'Recent',
+		// Tags with no posts have no date to sort by and sink to the bottom,
+		// where they order alphabetically among themselves.
+		compare: (a, b) => {
+			if (!a.latest && !b.latest) return byLabel(a, b);
+			if (!a.latest) return 1;
+			if (!b.latest) return -1;
+			return b.latest.valueOf() - a.latest.valueOf() || byLabel(a, b);
+		},
+	},
+];
+
+export const sortHref = (segment: string): string =>
+	segment === '' ? '/tags/' : `/tags/${segment}/`;
+
+/*
+	The sort orders are static routes under /tags/, and so are the tag pages.
+	A tag slugged "a-z" would quietly shadow one of them — Astro prefers the
+	static route and the tag page would never build. Cheaper to fail loudly
+	here than to wonder later why one tag 404s.
+*/
+{
+	const reserved = new Set(
+		TAG_SORTS.map((s) => s.segment).filter((s) => s !== ''),
+	);
+	const clash = TAG_KEYS.filter((key) => reserved.has(TAGS[key].slug));
+	if (clash.length > 0) {
+		throw new Error(
+			`Tag slug collides with a sort route: ${clash
+				.map((key) => `"${TAGS[key].slug}" (${key})`)
+				.join(', ')}. Rename the slug in src/lib/tags.ts.`,
+		);
+	}
+
+	// Two tags sharing a slug would collapse into one route, and keyBySlug
+	// would silently resolve to whichever was declared last.
+	const seen = new Set<string>();
+	const dupes = TAG_KEYS.filter((key) => {
+		const slug = TAGS[key].slug;
+		if (seen.has(slug)) return true;
+		seen.add(slug);
+		return false;
+	});
+	if (dupes.length > 0) {
+		throw new Error(
+			`Duplicate tag slug: ${dupes
+				.map((key) => `"${TAGS[key].slug}" (${key})`)
+				.join(', ')}. Slugs must be unique in src/lib/tags.ts.`,
+		);
+	}
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -4,6 +4,7 @@ import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Prose from '../../components/Prose.astro';
 import { PERSON_ID, WEBSITE_ID } from '../../lib/schema';
+import { TAGS, tagHref } from '../../lib/tags';
 
 export const getStaticPaths: GetStaticPaths = async () => {
 	// Drafts get a page in dev so they can be previewed, but never build into
@@ -58,7 +59,8 @@ const schema = {
 	author: { '@id': PERSON_ID },
 	publisher: { '@id': PERSON_ID },
 	image: new URL(`/og/blog/${post.id}.png`, Astro.site).href,
-	keywords: post.data.tags,
+	// Display labels, not internal keys — this field is read by crawlers.
+	keywords: post.data.tags.map((key) => TAGS[key].label),
 	isPartOf: { '@id': WEBSITE_ID },
 	mainEntityOfPage: url,
 };
@@ -92,10 +94,13 @@ const schema = {
 				{
 					post.data.tags.length > 0 && (
 						<div class="mt-4 flex flex-wrap gap-2">
-							{post.data.tags.map((tag) => (
-								<span class="border border-rule px-2.5 py-1 text-micro tracking-wider text-ink-muted uppercase">
-									{tag}
-								</span>
+							{post.data.tags.map((key) => (
+								<a
+									href={tagHref(key)}
+									class="border border-rule px-2.5 py-1 text-micro tracking-wider text-ink-muted uppercase no-underline transition-colors hover:border-accent hover:text-accent"
+								>
+									{TAGS[key].label}
+								</a>
 							))}
 						</div>
 					)

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,10 +1,8 @@
 ---
-import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { allPosts } from '../../lib/posts';
 
-const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
-	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
-);
+const posts = await allPosts();
 
 const stamp = (date: Date) =>
 	date

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -1,11 +1,10 @@
 import rss from '@astrojs/rss';
-import { getCollection } from 'astro:content';
 import type { APIRoute } from 'astro';
+import { allPosts } from '../lib/posts';
+import { TAGS } from '../lib/tags';
 
 export const GET: APIRoute = async (context) => {
-	const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
-		(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
-	);
+	const posts = await allPosts();
 
 	return rss({
 		title: 'Timothy Marias',
@@ -17,7 +16,8 @@ export const GET: APIRoute = async (context) => {
 			description: post.data.description,
 			pubDate: post.data.pubDate,
 			link: `/blog/${post.id}/`,
-			categories: post.data.tags,
+			// Display labels, not internal keys — a reader shows these verbatim.
+			categories: post.data.tags.map((key) => TAGS[key].label),
 		})),
 		customData: '<language>en-us</language>',
 	});

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,11 @@
 ---
-import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Section from '../components/Section.astro';
 import ProjectRow from '../components/ProjectRow.astro';
 import CopyEmail from '../components/CopyEmail.astro';
 import { PERSON_ID, WEBSITE_ID } from '../lib/schema';
+import { projects } from '../lib/projects';
+import { allPosts } from '../lib/posts';
 
 const status = [
 	{ label: 'Location', value: 'Oregon' },
@@ -12,42 +13,7 @@ const status = [
 	{ label: 'Building', value: 'Niche micromonopolies' },
 ];
 
-// Projects. Current work lives in the hero; the full history lives in the
-// résumé. `links` takes any mix of destinations — repo, live site, docs. Leave
-// it off when there is nothing public, and the row shows "Private" instead.
-const projects = [
-	{
-		index: '001',
-		title: 'Marias Family Archive',
-		summary:
-			"My WIP project to act as an archive for my family's genealogy from our primary sources." +
-			' Originally built out in Spring Boot with Kotlin, moving it now to Adonis JS. ' +
-			'SSR MPA with TS islands. Self hosted on my NixOS box.',
-		tags: ['Family Archive', 'Typescript', 'Postgres', 'NixOS'],
-		year: '2025—present',
-		links: [
-			{ label: 'Live', href: 'https://mariasfamilyarchive.com' },
-			{ label: 'Repo', href: 'https://github.com/timothyjamesmarias/familyArchive' },
-			{ label: 'Old', href: 'https://github.com/timothyjamesmarias/familyArchiveV1' }
-		],
-	},
-	{
-		index: '002',
-		title: 'Caelus',
-		summary: "A routing architecture library for being able to expose a program's API across multiple surfaces: keybindings and overrides, CLI, MCP, and web. " +
-			"Originally prototyped as a Kotlin Multiplatform Library, I'm in the process of porting this to TypeScript to be able to provide better web support.",
-		tags: ['Caelus', 'Typescript', 'Cross-platform'],
-		year: '2026—present',
-		links: [
-			{ label: 'Repo', href: 'https://github.com/ufo-soft/caelus' },
-			{ label: 'Old', href: 'https://github.com/ufo-soft/caelus-old' }
-		],
-	},
-];
-
-const posts = (await getCollection('blog', ({ data }) => !data.draft))
-	.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
-	.slice(0, 4);
+const posts = (await allPosts()).slice(0, 4);
 
 const hasNotes = posts.length > 0;
 

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -1,6 +1,7 @@
 import type { APIRoute, GetStaticPaths } from 'astro';
 import { getCollection } from 'astro:content';
 import { renderOgImage } from '../../lib/og.mjs';
+import { TAGS, TAG_KEYS } from '../../lib/tags';
 
 /**
  * Renders a 1200x630 card per page at build time. Uses the same headless
@@ -24,6 +25,14 @@ export const getStaticPaths: GetStaticPaths = async () => {
 			params: { slug: 'blog' },
 			props: { title: 'Notes', kicker: 'Writing' },
 		},
+		{
+			params: { slug: 'tags' },
+			props: { title: 'Tags', kicker: 'Index' },
+		},
+		...TAG_KEYS.map((key) => ({
+			params: { slug: `tags/${TAGS[key].slug}` },
+			props: { title: TAGS[key].label, kicker: 'Tag' },
+		})),
 		...posts.map((post) => ({
 			params: { slug: `blog/${post.id}` },
 			props: {

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -30,6 +30,26 @@ const counts = [
 		`${projects.length} ${projects.length === 1 ? 'project' : 'projects'}`,
 ].filter(Boolean) as string[];
 
+/*
+	Row chips are context — why this post is in this list, and what else it
+	touches — not a full index of its tags. The column is 220px, so past three
+	they stop informing and start crowding. The current tag leads, since it
+	answers the first question; the overflow is stated as plain text rather
+	than a control, because the row is already a link to the post, where the
+	complete set lives.
+*/
+const CHIP_LIMIT = 3;
+
+const rows = posts.map((post) => {
+	const ordered = [tagKey, ...post.data.tags.filter((key) => key !== tagKey)];
+	return {
+		post,
+		chips: ordered.slice(0, CHIP_LIMIT),
+		overflow: Math.max(0, ordered.length - CHIP_LIMIT),
+		minutes: readingMinutes(post),
+	};
+});
+
 const stamp = (date: Date) =>
 	date
 		.toLocaleDateString('en-GB', {
@@ -168,7 +188,7 @@ const isExternal = (href: string) => /^https?:\/\//.test(href);
 				</p>
 			) : (
 				<ul class="border-b border-rule-strong">
-					{posts.map((post, i) => (
+					{rows.map(({ post, chips, overflow, minutes }, i) => (
 						<li
 							class:list={[
 								i === 0 ? 'border-t border-rule-strong' : 'border-t border-rule',
@@ -203,8 +223,8 @@ const isExternal = (href: string) => /^https?:\/\//.test(href);
 								*/}
 								<div class="flex flex-wrap items-baseline gap-x-3 gap-y-1.5 sm:col-start-2 lg:contents">
 									{/* Chips inside the anchor, so they can't be links. */}
-									<div class="flex flex-wrap gap-1.5">
-										{post.data.tags.map((key) => (
+									<div class="flex flex-wrap items-baseline gap-1.5">
+										{chips.map((key) => (
 											<span
 												class:list={[
 													'px-[7px] py-[3px] text-micro tracking-wide uppercase',
@@ -216,10 +236,13 @@ const isExternal = (href: string) => /^https?:\/\//.test(href);
 												{TAGS[key].label}
 											</span>
 										))}
+										{overflow > 0 && (
+											<span class="text-micro text-ink-faint">+{overflow}</span>
+										)}
 									</div>
 
 									<span class="text-mini text-ink-faint lg:text-right">
-										{readingMinutes(post)} min
+										{minutes} min
 									</span>
 								</div>
 							</a>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,286 @@
+---
+import type { GetStaticPaths } from 'astro';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { postsByTag, relatedTags } from '../../lib/posts';
+import { projectsByTag } from '../../lib/projects';
+import { TAGS, TAG_KEYS, tagHref, type TagKey } from '../../lib/tags';
+import { WEBSITE_ID } from '../../lib/schema';
+
+export const getStaticPaths: GetStaticPaths = async () =>
+	// Every tag in the registry gets a route, including ones nothing references
+	// yet. The index links only the used ones, so an empty page isn't reachable
+	// by browsing — but a hand-written link to it still resolves.
+	TAG_KEYS.map((key) => ({
+		params: { tag: TAGS[key].slug },
+		props: { tagKey: key },
+	}));
+
+const { tagKey } = Astro.props as { tagKey: TagKey };
+const tag = TAGS[tagKey];
+
+const posts = await postsByTag(tagKey);
+const projects = projectsByTag(tagKey);
+const related = await relatedTags(tagKey);
+const feedHref = `/tags/${tag.slug}/feed.xml`;
+
+// "7 notes · 2 projects" — each half only appears if it has something to say.
+const counts = [
+	posts.length > 0 && `${posts.length} ${posts.length === 1 ? 'note' : 'notes'}`,
+	projects.length > 0 &&
+		`${projects.length} ${projects.length === 1 ? 'project' : 'projects'}`,
+].filter(Boolean) as string[];
+
+const stamp = (date: Date) =>
+	date
+		.toLocaleDateString('en-GB', {
+			year: '2-digit',
+			month: '2-digit',
+			day: '2-digit',
+			timeZone: 'UTC',
+		})
+		.split('/')
+		.reverse()
+		.join('.');
+
+const url = new URL(Astro.url.pathname, Astro.site).href;
+
+// A CollectionPage rather than a plain WebPage: the tag's value is the list,
+// and the entries are what the page is actually about.
+const schema = {
+	'@type': 'CollectionPage',
+	'@id': `${url}#page`,
+	url,
+	name: tag.label,
+	...(tag.description && { description: tag.description }),
+	isPartOf: { '@id': WEBSITE_ID },
+	mainEntity: {
+		'@type': 'ItemList',
+		numberOfItems: posts.length,
+		itemListElement: posts.map((post, i) => ({
+			'@type': 'ListItem',
+			position: i + 1,
+			url: new URL(`/blog/${post.id}/`, Astro.site).href,
+			name: post.data.title,
+		})),
+	},
+};
+
+const isExternal = (href: string) => /^https?:\/\//.test(href);
+---
+
+<BaseLayout
+	title={tag.label}
+	description={tag.description ?? `Everything tagged ${tag.label}.`}
+	image={`/og/tags/${tag.slug}.png`}
+	feed={posts.length > 0
+		? { href: feedHref, title: `Timothy Marias — ${tag.label}` }
+		: undefined}
+	schema={schema}
+>
+	{/* Breadcrumb — the only place the page states where it sits. */}
+	<nav
+		aria-label="Breadcrumb"
+		class="flex items-baseline gap-2.5 border-b border-rule px-6 py-5 text-mini tracking-wider uppercase md:px-18"
+	>
+		<a href="/blog/" class="text-ink-faint no-underline hover:text-ink">Notes</a>
+		<span class="text-ink-faint" aria-hidden="true">/</span>
+		<a href="/tags/" class="text-ink-faint no-underline hover:text-ink">Tags</a>
+		<span class="text-ink-faint" aria-hidden="true">/</span>
+		<span class="text-ink" aria-current="page">{tag.label}</span>
+	</nav>
+
+	<div
+		class="grid grid-cols-1 gap-x-8 gap-y-10 px-6 pt-14 pb-10 md:grid-cols-[96px_1fr] md:px-18 lg:grid-cols-[96px_1fr_300px]"
+	>
+		<span class="eyebrow pt-2.5">Tag</span>
+
+		<div>
+			<div class="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+				<h1
+					class="text-[2.25rem] leading-display font-bold tracking-tightest text-pretty sm:text-[2.875rem]"
+				>
+					{tag.label}
+				</h1>
+				{
+					counts.length > 0 && (
+						<p class="text-small text-ink-faint">{counts.join(' · ')}</p>
+					)
+				}
+			</div>
+			{
+				tag.description && (
+					<p class="mt-[18px] max-w-[480px] text-[0.9375rem] leading-normal text-ink-muted">
+						{tag.description}
+					</p>
+				)
+			}
+		</div>
+
+		<aside class="flex flex-col gap-3 lg:border-l lg:border-rule lg:pl-6">
+			{
+				related.length > 0 && (
+					<>
+						<span class="text-micro tracking-[0.1em] text-ink-faint uppercase">
+							Often with
+						</span>
+						<div class="flex flex-wrap gap-1.5">
+							{related.map((entry) => (
+								<a
+									href={tagHref(entry.key)}
+									class="border border-rule px-2 py-1 text-micro tracking-wide text-ink-muted uppercase no-underline transition-colors hover:border-accent hover:text-accent"
+								>
+									{TAGS[entry.key].label}{' '}
+									<span class="text-ink-faint">{entry.count}</span>
+								</a>
+							))}
+						</div>
+					</>
+				)
+			}
+
+			{/* Only worth offering once there is something to deliver. */}
+			{
+				posts.length > 0 && (
+					<p
+						class:list={[
+							'text-caption text-ink-faint',
+							related.length > 0 && 'mt-1.5 border-t border-rule pt-3',
+						]}
+					>
+						Subscribe to this tag{' '}
+						<a
+							href={feedHref}
+							class="border-b border-ink text-ink no-underline transition-colors hover:border-accent hover:text-accent"
+						>
+							RSS <span class="text-accent">&#8599;</span>
+						</a>
+					</p>
+				)
+			}
+		</aside>
+	</div>
+
+	{
+		projects.length > 0 && (
+			<section class="grid grid-cols-1 gap-x-8 px-6 pb-14 md:grid-cols-[96px_1fr] md:px-18">
+				<h2 class="eyebrow pb-4 md:pb-0">Projects</h2>
+				<ul class="border-b border-rule-strong">
+					{projects.map((project, i) => (
+						<li
+							class:list={[
+								'grid grid-cols-1 items-baseline gap-x-6 gap-y-2 py-4 sm:grid-cols-[40px_1fr_200px]',
+								i === 0
+									? 'border-t border-rule-strong'
+									: 'border-t border-rule',
+							]}
+						>
+							<span class="eyebrow font-mono">{project.index}</span>
+
+							<div>
+								<h3 class="text-[1.0625rem] font-bold tracking-tight text-ink">
+									{project.title}
+								</h3>
+								<p class="mt-[5px] max-w-[460px] text-small leading-normal text-ink-muted">
+									{project.summary}
+								</p>
+							</div>
+
+							<div class="flex flex-col gap-2.5 sm:items-end">
+								<span class="text-mini text-ink-faint">{project.year}</span>
+								{(project.links ?? []).length > 0 ? (
+									<div class="flex flex-wrap gap-3.5">
+										{project.links!.map((link) => (
+											<a
+												href={link.href}
+												target={isExternal(link.href) ? '_blank' : undefined}
+												rel={
+													isExternal(link.href)
+														? 'noopener noreferrer'
+														: undefined
+												}
+												class="flex items-baseline gap-[5px] border-b border-ink pb-[3px] text-micro tracking-wider text-ink uppercase no-underline transition-colors hover:border-accent hover:text-accent"
+											>
+												<span>{link.label}</span>
+												{isExternal(link.href) && (
+													<span class="text-accent">&#8599;</span>
+												)}
+											</a>
+										))}
+									</div>
+								) : (
+									<span class="text-micro tracking-wider text-ink-faint uppercase">
+										Private
+									</span>
+								)}
+							</div>
+						</li>
+					))}
+				</ul>
+			</section>
+		)
+	}
+
+	<section
+		class="grid grid-cols-1 gap-x-8 px-6 pb-16 md:grid-cols-[96px_1fr] md:px-18"
+	>
+		<h2 class="eyebrow pb-4 md:pb-0">Notes</h2>
+		{
+			posts.length === 0 ? (
+				<p class="text-small text-ink-muted">
+					Nothing written under this tag yet.
+				</p>
+			) : (
+				<ul class="border-b border-rule-strong">
+					{posts.map((post, i) => (
+						<li
+							class:list={[
+								i === 0 ? 'border-t border-rule-strong' : 'border-t border-rule',
+							]}
+						>
+							<a
+								href={`/blog/${post.id}/`}
+								class="group grid grid-cols-1 items-baseline gap-x-6 gap-y-2 py-[18px] no-underline sm:grid-cols-[90px_1fr] lg:grid-cols-[90px_1fr_220px]"
+							>
+								<time
+									datetime={post.data.pubDate.toISOString()}
+									class="text-mini font-mono text-ink-faint"
+								>
+									{stamp(post.data.pubDate)}
+								</time>
+
+								<div>
+									<h3 class="text-[1.0625rem] font-bold tracking-tight text-ink transition-colors group-hover:text-accent">
+										{post.data.title}
+									</h3>
+									<p class="mt-[5px] max-w-[460px] text-small leading-normal text-ink-muted">
+										{post.data.description}
+									</p>
+								</div>
+
+								{/*
+									Chips inside the row's anchor, so they can't be links
+									themselves. The current tag is filled to show why the
+									post is in this list.
+								*/}
+								<div class="hidden flex-wrap gap-1.5 lg:flex">
+									{post.data.tags.map((key) => (
+										<span
+											class:list={[
+												'px-[7px] py-[3px] text-micro tracking-wide uppercase',
+												key === tagKey
+													? 'border border-rule-strong bg-rule-strong text-page'
+													: 'border border-rule text-ink-muted',
+											]}
+										>
+											{TAGS[key].label}
+										</span>
+									))}
+								</div>
+							</a>
+						</li>
+					))}
+				</ul>
+			)
+		}
+	</section>
+</BaseLayout>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -157,66 +157,6 @@ const isExternal = (href: string) => /^https?:\/\//.test(href);
 		</aside>
 	</div>
 
-	{
-		projects.length > 0 && (
-			<section class="grid grid-cols-1 gap-x-8 px-6 pb-14 md:grid-cols-[96px_1fr] md:px-18">
-				<h2 class="eyebrow pb-4 md:pb-0">Projects</h2>
-				<ul class="border-b border-rule-strong">
-					{projects.map((project, i) => (
-						<li
-							class:list={[
-								'grid grid-cols-1 items-baseline gap-x-6 gap-y-2 py-4 sm:grid-cols-[40px_1fr_200px]',
-								i === 0
-									? 'border-t border-rule-strong'
-									: 'border-t border-rule',
-							]}
-						>
-							<span class="eyebrow font-mono">{project.index}</span>
-
-							<div>
-								<h3 class="text-[1.0625rem] font-bold tracking-tight text-ink">
-									{project.title}
-								</h3>
-								<p class="mt-[5px] max-w-[460px] text-small leading-normal text-ink-muted">
-									{project.summary}
-								</p>
-							</div>
-
-							<div class="flex flex-col gap-2.5 sm:items-end">
-								<span class="text-mini text-ink-faint">{project.year}</span>
-								{(project.links ?? []).length > 0 ? (
-									<div class="flex flex-wrap gap-3.5">
-										{project.links!.map((link) => (
-											<a
-												href={link.href}
-												target={isExternal(link.href) ? '_blank' : undefined}
-												rel={
-													isExternal(link.href)
-														? 'noopener noreferrer'
-														: undefined
-												}
-												class="flex items-baseline gap-[5px] border-b border-ink pb-[3px] text-micro tracking-wider text-ink uppercase no-underline transition-colors hover:border-accent hover:text-accent"
-											>
-												<span>{link.label}</span>
-												{isExternal(link.href) && (
-													<span class="text-accent">&#8599;</span>
-												)}
-											</a>
-										))}
-									</div>
-								) : (
-									<span class="text-micro tracking-wider text-ink-faint uppercase">
-										Private
-									</span>
-								)}
-							</div>
-						</li>
-					))}
-				</ul>
-			</section>
-		)
-	}
-
 	<section
 		class="grid grid-cols-1 gap-x-8 px-6 pb-16 md:grid-cols-[96px_1fr] md:px-18"
 	>
@@ -280,4 +220,64 @@ const isExternal = (href: string) => /^https?:\/\//.test(href);
 			)
 		}
 	</section>
+
+	{
+		projects.length > 0 && (
+			<section class="grid grid-cols-1 gap-x-8 px-6 pb-14 md:grid-cols-[96px_1fr] md:px-18">
+				<h2 class="eyebrow pb-4 md:pb-0">Projects</h2>
+				<ul class="border-b border-rule-strong">
+					{projects.map((project, i) => (
+						<li
+							class:list={[
+								'grid grid-cols-1 items-baseline gap-x-6 gap-y-2 py-4 sm:grid-cols-[40px_1fr_200px]',
+								i === 0
+									? 'border-t border-rule-strong'
+									: 'border-t border-rule',
+							]}
+						>
+							<span class="eyebrow font-mono">{project.index}</span>
+
+							<div>
+								<h3 class="text-[1.0625rem] font-bold tracking-tight text-ink">
+									{project.title}
+								</h3>
+								<p class="mt-[5px] max-w-[460px] text-small leading-normal text-ink-muted">
+									{project.summary}
+								</p>
+							</div>
+
+							<div class="flex flex-col gap-2.5 sm:items-end">
+								<span class="text-mini text-ink-faint">{project.year}</span>
+								{(project.links ?? []).length > 0 ? (
+									<div class="flex flex-wrap gap-3.5">
+										{project.links!.map((link) => (
+											<a
+												href={link.href}
+												target={isExternal(link.href) ? '_blank' : undefined}
+												rel={
+													isExternal(link.href)
+														? 'noopener noreferrer'
+														: undefined
+												}
+												class="flex items-baseline gap-[5px] border-b border-ink pb-[3px] text-micro tracking-wider text-ink uppercase no-underline transition-colors hover:border-accent hover:text-accent"
+											>
+												<span>{link.label}</span>
+												{isExternal(link.href) && (
+													<span class="text-accent">&#8599;</span>
+												)}
+											</a>
+										))}
+									</div>
+								) : (
+									<span class="text-micro tracking-wider text-ink-faint uppercase">
+										Private
+									</span>
+								)}
+							</div>
+						</li>
+					))}
+				</ul>
+			</section>
+		)
+	}
 </BaseLayout>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,7 +1,7 @@
 ---
 import type { GetStaticPaths } from 'astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import { postsByTag, relatedTags } from '../../lib/posts';
+import { postsByTag, readingMinutes, relatedTags } from '../../lib/posts';
 import { projectsByTag } from '../../lib/projects';
 import { TAGS, TAG_KEYS, tagHref, type TagKey } from '../../lib/tags';
 import { WEBSITE_ID } from '../../lib/schema';
@@ -176,7 +176,7 @@ const isExternal = (href: string) => /^https?:\/\//.test(href);
 						>
 							<a
 								href={`/blog/${post.id}/`}
-								class="group grid grid-cols-1 items-baseline gap-x-6 gap-y-2 py-[18px] no-underline sm:grid-cols-[90px_1fr] lg:grid-cols-[90px_1fr_220px]"
+								class="group grid grid-cols-1 items-baseline gap-x-6 gap-y-2 py-[18px] no-underline sm:grid-cols-[90px_1fr] lg:grid-cols-[90px_1fr_220px_80px]"
 							>
 								<time
 									datetime={post.data.pubDate.toISOString()}
@@ -195,23 +195,32 @@ const isExternal = (href: string) => /^https?:\/\//.test(href);
 								</div>
 
 								{/*
-									Chips inside the row's anchor, so they can't be links
-									themselves. The current tag is filled to show why the
-									post is in this list.
+									Chips and read time share a line below lg, wrapping under
+									the title; at lg the wrapper dissolves (display: contents)
+									so each becomes its own grid column, as the design has it.
+									One copy of each either way — duplicating them per
+									breakpoint would have a screen reader announce them twice.
 								*/}
-								<div class="hidden flex-wrap gap-1.5 lg:flex">
-									{post.data.tags.map((key) => (
-										<span
-											class:list={[
-												'px-[7px] py-[3px] text-micro tracking-wide uppercase',
-												key === tagKey
-													? 'border border-rule-strong bg-rule-strong text-page'
-													: 'border border-rule text-ink-muted',
-											]}
-										>
-											{TAGS[key].label}
-										</span>
-									))}
+								<div class="flex flex-wrap items-baseline gap-x-3 gap-y-1.5 sm:col-start-2 lg:contents">
+									{/* Chips inside the anchor, so they can't be links. */}
+									<div class="flex flex-wrap gap-1.5">
+										{post.data.tags.map((key) => (
+											<span
+												class:list={[
+													'px-[7px] py-[3px] text-micro tracking-wide uppercase',
+													key === tagKey
+														? 'border border-rule-strong bg-rule-strong text-page'
+														: 'border border-rule text-ink-muted',
+												]}
+											>
+												{TAGS[key].label}
+											</span>
+										))}
+									</div>
+
+									<span class="text-mini text-ink-faint lg:text-right">
+										{readingMinutes(post)} min
+									</span>
 								</div>
 							</a>
 						</li>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -72,9 +72,7 @@ const isExternal = (href: string) => /^https?:\/\//.test(href);
 	title={tag.label}
 	description={tag.description ?? `Everything tagged ${tag.label}.`}
 	image={`/og/tags/${tag.slug}.png`}
-	feed={posts.length > 0
-		? { href: feedHref, title: `Timothy Marias — ${tag.label}` }
-		: undefined}
+	feed={{ href: feedHref, title: `Timothy Marias — ${tag.label}` }}
 	schema={schema}
 >
 	{/* Breadcrumb — the only place the page states where it sits. */}
@@ -138,25 +136,24 @@ const isExternal = (href: string) => /^https?:\/\//.test(href);
 				)
 			}
 
-			{/* Only worth offering once there is something to deliver. */}
-			{
-				posts.length > 0 && (
-					<p
-						class:list={[
-							'text-caption text-ink-faint',
-							related.length > 0 && 'mt-1.5 border-t border-rule pt-3',
-						]}
-					>
-						Subscribe to this tag{' '}
-						<a
-							href={feedHref}
-							class="border-b border-ink text-ink no-underline transition-colors hover:border-accent hover:text-accent"
-						>
-							RSS <span class="text-accent">&#8599;</span>
-						</a>
-					</p>
-				)
-			}
+			{/*
+				Always offered. The feed route is built for every tag, so an early
+				subscription simply starts delivering once the tag has posts.
+			*/}
+			<p
+				class:list={[
+					'text-caption text-ink-faint',
+					related.length > 0 && 'mt-1.5 border-t border-rule pt-3',
+				]}
+			>
+				Subscribe to this tag{' '}
+				<a
+					href={feedHref}
+					class="border-b border-ink text-ink no-underline transition-colors hover:border-accent hover:text-accent"
+				>
+					RSS <span class="text-accent">&#8599;</span>
+				</a>
+			</p>
 		</aside>
 	</div>
 

--- a/src/pages/tags/[tag]/feed.xml.ts
+++ b/src/pages/tags/[tag]/feed.xml.ts
@@ -1,0 +1,36 @@
+import rss from '@astrojs/rss';
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { postsByTag } from '../../../lib/posts';
+import { TAGS, TAG_KEYS, type TagKey } from '../../../lib/tags';
+
+/**
+ * One feed per tag, so a reader can subscribe to a single subject rather than
+ * everything. Built for every tag in the registry — including empty ones, so
+ * a subscription taken out early starts delivering once the tag has posts.
+ */
+
+export const getStaticPaths: GetStaticPaths = async () =>
+	TAG_KEYS.map((key) => ({
+		params: { tag: TAGS[key].slug },
+		props: { tagKey: key },
+	}));
+
+export const GET: APIRoute = async (context) => {
+	const { tagKey } = context.props as { tagKey: TagKey };
+	const tag = TAGS[tagKey];
+	const posts = await postsByTag(tagKey);
+
+	return rss({
+		title: `Timothy Marias — ${tag.label}`,
+		description: tag.description ?? `Notes tagged ${tag.label}.`,
+		site: context.site!,
+		items: posts.map((post) => ({
+			title: post.data.title,
+			description: post.data.description,
+			pubDate: post.data.pubDate,
+			link: `/blog/${post.id}/`,
+			categories: post.data.tags.map((key) => TAGS[key].label),
+		})),
+		customData: '<language>en-us</language>',
+	});
+};

--- a/src/pages/tags/a-z.astro
+++ b/src/pages/tags/a-z.astro
@@ -1,0 +1,7 @@
+---
+import TagIndex from '../../components/TagIndex.astro';
+
+// Alphabetical ordering of /tags/. Canonicalises back to it.
+---
+
+<TagIndex segment="a-z" />

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,0 +1,8 @@
+---
+import TagIndex from '../../components/TagIndex.astro';
+
+// The canonical tag index. Sorted by weight — see TAG_SORTS for why the
+// other orderings are their own pages rather than a client-side control.
+---
+
+<TagIndex segment="" />

--- a/src/pages/tags/recent.astro
+++ b/src/pages/tags/recent.astro
@@ -1,0 +1,7 @@
+---
+import TagIndex from '../../components/TagIndex.astro';
+
+// Most-recently-written ordering of /tags/. Canonicalises back to it.
+---
+
+<TagIndex segment="recent" />


### PR DESCRIPTION
Tags were free-form strings written independently in project rows and post frontmatter, which had already drifted — "Typescript"/"TypeScript" and "Cross-platform"/"Cross-Platform" were four tags, not two. With no CMS to enforce a vocabulary, the fix is a registry that both sides key into.

src/lib/tags.ts holds one record per tag. Content frontmatter validates against those keys via z.enum, so a typo fails the build naming the file and the valid options rather than shipping a page that links nowhere. Projects type their tags as TagKey, catching the same mistake in the editor. Guards reject duplicate slugs and slugs that would shadow a sort route.

Projects move out of the home page into src/lib/projects.ts because tag pages list them too: a tag like Caelus names both a project and the notes about it, and surfacing that connection is the point of the feature.

The tag index sorts three ways. Each ordering is its own pre-built page rather than a client-side control — the build already knows every ordering, so shipping a comparator would only re-derive it. Three plain links need no JS, keep DOM order correct for keyboard and screen readers, and are shareable; the variants canonicalise back to /tags/. Comparators take a plain row shape so the logic can move to the browser unchanged if faceting ever demands it.

Single-entry tags collapse into one chip row under Weight only. That view is about relative mass and a long tail of ones drowns out the tags carrying the site; A-Z and Recent are lookup views, where collapsing would hide half the alphabet.

Also emit display labels rather than internal keys in RSS categories and BlogPosting keywords — both are read verbatim by consumers.

The project directory is un-ignored explicitly: a global gitignore rule for the ctags TAGS file also matches src/pages/tags on a case-insensitive filesystem, which would have silently excluded every page here.